### PR TITLE
Add expected approach type to VHHH vATIS profile

### DIFF
--- a/vATIS Profile - Hong Kong FIR VHHK 2402.json
+++ b/vATIS Profile - Hong Kong FIR VHHK 2402.json
@@ -522,7 +522,7 @@
         },
         {
           "description": "",
-          "ordinal": 10,
+          "ordinal": 12,
           "text": "RWY SFC ALL PARTS WET.",
           "enabled": false
         }

--- a/vATIS Profile - Hong Kong FIR VHHK 2402.json
+++ b/vATIS Profile - Hong Kong FIR VHHK 2402.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hong Kong FIR VHHK 2305",
+  "name": "Hong Kong FIR VHHK 2402",
   "id": "f01a4b2c-3caf-43ca-8d8e-e574a5792ec9",
   "composites": [
     {
@@ -62,7 +62,7 @@
         },
         {
           "string": "MAINT",
-          "spoken": "MAINTAINENCE"
+          "spoken": "MAINTENANCE"
         },
         {
           "string": "CLSD",
@@ -418,7 +418,7 @@
         },
         {
           "string": "MAINT",
-          "spoken": "MAINTAINENCE"
+          "spoken": "MAINTENANCE"
         },
         {
           "string": "CLSD",
@@ -427,6 +427,30 @@
         {
           "string": "VCY",
           "spoken": "VICINITY"
+        },
+        {
+          "string": "RNP",
+          "spoken": "R N P"
+        },
+        {
+          "string": "ILS",
+          "spoken": "I L S"
+        },
+        {
+          "string": "RNAV",
+          "spoken": "R NAV"
+        },
+        {
+          "string": "APCH",
+          "spoken": "APPROACH"
+        },
+        {
+          "string": "REQ",
+          "spoken": "REQUEST"
+        },
+        {
+          "string": "AVBL",
+          "spoken": "AVAILABLE"
         }
       ],
       "airportConditionDefinitions": [
@@ -469,12 +493,36 @@
         {
           "description": "",
           "ordinal": 7,
-          "text": "SIG WS FCST.",
+          "text": "EXP ILS APCH.",
           "enabled": false
         },
         {
           "description": "",
           "ordinal": 8,
+          "text": "EXP RNAV TRANSITION TO ILS APCH.",
+          "enabled": false
+        },
+        {
+          "description": "",
+          "ordinal": 9,
+          "text": "RNP APCH IS AVBL ON REQ.",
+          "enabled": false
+        },
+        {
+          "description": "",
+          "ordinal": 10,
+          "text": "SIG WS FCST.",
+          "enabled": false
+        },
+        {
+          "description": "",
+          "ordinal": 11,
+          "text": "SIG WS AND MOD TURB FCST.",
+          "enabled": false
+        },
+        {
+          "description": "",
+          "ordinal": 10,
           "text": "RWY SFC ALL PARTS WET.",
           "enabled": false
         }

--- a/vATIS Profile - Hong Kong FIR VHHK 2402.json
+++ b/vATIS Profile - Hong Kong FIR VHHK 2402.json
@@ -45,16 +45,16 @@
           "spoken": "SIGNIFICANT"
         },
         {
-          "string": "MET",
-          "spoken": "METAR"
-        },
-        {
           "string": "WS",
           "spoken": "WINDSHEAR"
         },
         {
           "string": "FCST",
           "spoken": "FORECAST"
+        },
+        {
+          "string": "BASELEG",
+          "spoken": "BASE LEG"
         },
         {
           "string": "MET REPORT",
@@ -69,20 +69,32 @@
           "spoken": "CLOSED"
         },
         {
-          "string": "TURB",
-          "spoken": "TURBULENCE"
-        },
-        {
-          "string": "MOD",
-          "spoken": "MODERATE"
-        },
-        {
           "string": "VCY",
           "spoken": "VICINITY"
         },
         {
-          "string": "TS",
-          "spoken": "THUNDERSTORM"
+          "string": "RNP",
+          "spoken": "R ENN P"
+        },
+        {
+          "string": "ILS",
+          "spoken": "I L ESS"
+        },
+        {
+          "string": "RNAV",
+          "spoken": "R NAV"
+        },
+        {
+          "string": "APCH",
+          "spoken": "APPROACH"
+        },
+        {
+          "string": "REQ",
+          "spoken": "REQUEST"
+        },
+        {
+          "string": "AVBL",
+          "spoken": "AVAILABLE"
         }
       ],
       "airportConditionDefinitions": [
@@ -397,10 +409,6 @@
           "spoken": "SIGNIFICANT"
         },
         {
-          "string": "MET",
-          "spoken": "METAR"
-        },
-        {
           "string": "WS",
           "spoken": "WINDSHEAR"
         },
@@ -430,11 +438,11 @@
         },
         {
           "string": "RNP",
-          "spoken": "R N P"
+          "spoken": "R ENN P"
         },
         {
           "string": "ILS",
-          "spoken": "I L S"
+          "spoken": "I L ESS"
         },
         {
           "string": "RNAV",

--- a/vATIS Profile - Hong Kong FIR VHHK.json
+++ b/vATIS Profile - Hong Kong FIR VHHK.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hong Kong FIR VHHK 2402",
+  "name": "Hong Kong FIR VHHK",
   "id": "f01a4b2c-3caf-43ca-8d8e-e574a5792ec9",
   "composites": [
     {


### PR DESCRIPTION
Added:
"EXP ILS APCH."
"EXP RNAV TRANSITION TO ILS APCH."
"RNP APCH IS AVBL ON REQ."
as per https://atis.cad.gov.hk/ATIS/ATISweb/atis.php

![image](https://github.com/vatsimhk/Hong-Kong-Sector-Package/assets/89831445/8efe6fe8-56bc-4a9d-8a4f-4d6422c24405)
![image](https://github.com/vatsimhk/Hong-Kong-Sector-Package/assets/89831445/66a0e3b0-cac7-4454-8aeb-af151bafbd28)
![image](https://github.com/vatsimhk/Hong-Kong-Sector-Package/assets/89831445/c021cb75-1b8e-48c7-94ce-560f9d7bef02)
