### PR TITLE
Delete default Euroscope ATIS setting of VHHH and VMMC

### DIFF
--- a/Hong Kong TOPSKY.prf
+++ b/Hong Kong TOPSKY.prf
@@ -82,22 +82,10 @@ TeamSpeakVccs	Ts3NickName	<Your CID Here>
 Plugins	Plugin5	\Data\Plugins\Mplugin_1.0\MAESTRO.dll
 Plugins	Plugin2Display2	Ground Radar display
 Plugins	Plugin0Display2	Ground Radar display
-LastSession	atis_freq0	127050
-LastSession	atis_callsign0	VHHH_D_ATIS
-LastSession	atis_url0	http://vathk.com/atis/atis.php?dep=$deprwy($atisairportA)&info=$atiscodeA&metar=$metar($atisairportA)
-LastSession	atis_letter0	74
-LastSession	atis_freq1	128200
-LastSession	atis_callsign1	VHHH_A_ATIS
-LastSession	atis_url1	http://vathk.com/atis/atis.php?arr=$arrrwy($atisairportB)&apptype=ILS&info=$atiscodeB&metar=$metar($atisairportB)
-LastSession	atis_letter1	75
-LastSession	atis_freq2	126400
-LastSession	atis_callsign2	VMMC_ATIS
-LastSession	atis_url2	http://vathk.com/atis/atis.php?arr=$arrrwy($atisairportC)&dep=$deprwy($atisairportC)&apptype=ILS&info=$atiscodeC&metar=$metar($atisairportC)
-LastSession	atis_letter2	75
-LastSession	atis_freq3	122075
-LastSession	atis_callsign3	VHHX_ATIS
-LastSession	atis_url3	http://vathk.com/atis/atis.php?arr=$arrrwy($atisairportD)&dep=$deprwy($atisairportD)&apptype=ILS&info=$atiscodeD&metar=$metar(VHHH)
-LastSession	atis_letter3	75
+LastSession	atis_freq0	122074
+LastSession	atis_callsign0	VHHX_ATIS
+LastSession	atis_url0	http://vathk.com/atis/atis.php?dep=$deprwy(VHHX)&info=$atiscodeA&metar=$metar(VHHH)
+LastSession	atis_letter0	75
 Settings	SettingsfileORIGPLANE	\Data\Settings\GeneralSettings.txt
 Settings	SettingsfileSTUP	\Data\Settings\Lists.txt
 Settings	SettingsfileTAXIOUT	\Data\Settings\GeneralSettings.txt
@@ -106,7 +94,6 @@ Settings	SettingsfileADCS	\Data\Settings\GeneralSettings.txt
 Settings	SettingsfileTAXIIN	\Data\Settings\GeneralSettings.txt
 LastSession	rating	0
 LastSession	range	100
-LastSession	atis_freq4	118000
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\Data\Plugins\HKCP\HKCP.dll
 Plugins	Plugin6Display0	Standard ES radar screen


### PR DESCRIPTION
Only vATIS supports displaying dynamic information depending on runway configuration.